### PR TITLE
adding a notice that this site is not longer updated

### DIFF
--- a/rome_app/templates/rome_templates/index.html
+++ b/rome_app/templates/rome_templates/index.html
@@ -1,6 +1,7 @@
 {% extends "rome_templates/base.html"%}
 
 {% block page_head %}
+<p style="display: flex; border: solid 2px red; padding: 1rem; font-size: 1.25rem; margin: 0 200px 0 0;"><span style="font-size: 2rem; padding-right: 1rem;">★</span><span>Please note: this site is no longer updated and may not conform to modern accessibility requirements. If you need assistance, please contact <a href="mailto:library-accessibility@brown.edu">the library accessibility team</a>.</span></p>
 <h1>{{title}}</h1>
 <div class="intro"><h2>A Virtual Roman Library</h2></div>
 <div class="page_icon"></div>


### PR DESCRIPTION
For the upcoming accessibility requirements, we're adding a banner on older sites to notify users that the site is no longer updated and may not be accessible.